### PR TITLE
Add appveyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+os:
+  - Visual Studio 2017
+
+# x86 and x64 platforms.
+platform:
+  - x86
+  - x64
+
+# build Configurations, i.e. Debug, Release, etc.
+configuration:
+  - Release
+
+# build with MSBuild
+build:
+  project: CChromaEditor.sln        # path to Visual Studio solution or project
+
+artifacts:
+  - path: '**\*.dll'


### PR DESCRIPTION
We can build dll 32 and 64 bits using appveyor.

example of url:

jobs: https://ci.appveyor.com/project/mercuriete/cchromaeditor/builds/35941481

64 bits https://ci.appveyor.com/api/buildjobs/vj914h88a4m90vy7/artifacts/x64%2FRelease%2FCChromaEditorLibrary.dll
32 bits https://ci.appveyor.com/api/buildjobs/km9p8klg1xshva8v/artifacts/Release%2FCChromaEditorLibrary.dll

Thanks for your work.
